### PR TITLE
Centers map at user's location, if possible

### DIFF
--- a/src/main/webapp/ChapMap.js
+++ b/src/main/webapp/ChapMap.js
@@ -82,7 +82,7 @@ class ChapMap {
    * Adds click listeners to the map customization buttons.
    * A client can only add markers when the "adding markers" mode is on
    */
-   addBtnListeners_() {
+  addBtnListeners_() {
     let addMarkerBtn = this.getEl_("addMarkerBtnWrapper");
     let backBtn = this.getEl_("backBtnWrapper");
     let viewBtn = this.getEl_("viewBtnWrapper");

--- a/src/main/webapp/ChapMap.js
+++ b/src/main/webapp/ChapMap.js
@@ -35,11 +35,15 @@ class ChapMap {
 
   static SELECTED_CLASS = "selected";
 
-  constructor() {
+  
+  constructor(coords) {
+    var lat = coords[0];
+    var lng = coords[1];
+
     this.googleMap_ = new google.maps.Map(document.getElementById("map"), {
-        center: { lat: -34.397, lng: 150.644 },
-        zoom: 8
-      });
+      center: { lat: lat, lng: lng },
+      zoom: 8
+    });
 
     this.addBtnListeners_();
     this.addMapClickListener_();
@@ -52,7 +56,10 @@ class ChapMap {
 
     this.permMarkers_ = {};
     this.loadMarkers_();
+
   }
+    
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // LISTENERS
 
@@ -75,7 +82,7 @@ class ChapMap {
    * Adds click listeners to the map customization buttons.
    * A client can only add markers when the "adding markers" mode is on
    */
-  addBtnListeners_() {
+   addBtnListeners_() {
     let addMarkerBtn = this.getEl_("addMarkerBtnWrapper");
     let backBtn = this.getEl_("backBtnWrapper");
     let viewBtn = this.getEl_("viewBtnWrapper");

--- a/src/main/webapp/chat.js
+++ b/src/main/webapp/chat.js
@@ -127,6 +127,7 @@ function handleChatMessage(obj) {
   var node = document.createElement("div");
   var textnode = document.createTextNode(obj.name + ": " + obj.message);
 
+  // userID is defined in the main.js file
   if(obj.uid === userId) {
     node.classList.add("myMessage");
   } else {

--- a/src/main/webapp/chat.js
+++ b/src/main/webapp/chat.js
@@ -127,7 +127,6 @@ function handleChatMessage(obj) {
   var node = document.createElement("div");
   var textnode = document.createTextNode(obj.name + ": " + obj.message);
 
-  let userId = firebase.auth().currentUser.uid;
   if(obj.uid === userId) {
     node.classList.add("myMessage");
   } else {

--- a/src/main/webapp/main.js
+++ b/src/main/webapp/main.js
@@ -48,6 +48,7 @@ let firebasePromise = new Promise(function(resolve) {
     });
 
 let connection = null;
+let userId = null;
 
 /** Waits until all promises are fullfilled before opening the websocket and
  * setting up the map and chat
@@ -58,10 +59,14 @@ Promise.all([mapPromise, domPromise, firebasePromise]).then(() => {
         location.href = "/";
       }
 
+      userId = firebase.auth().currentUser.uid;
       getServerUrl().then(result => {
         connection = new WebSocket(result);
         initWebsocket();
-        myMap = new ChapMap();
+        // set lat and lng
+        
+
+        myMap = new ChapMap(getCoords());
         initChat();
       });
     });
@@ -140,4 +145,26 @@ function initChat() {
     document.getElementById("submitBtn").click();
     }
   });
+}
+
+function getCoords(){
+  var latitude;
+  var longitude;
+
+  if(navigator.geolocation){
+    navigator.geolocation.getCurrentPosition((position) => {
+      latitude = position.coords.latitude,
+      longitude = position.coords.longitude;
+    }, handle_error);
+  } else {
+    latitude = -34.397;
+    longitude = 150.644;
+  }
+
+  return [latitude, longitude];
+
+}
+
+function handle_error(err) {
+  console.log(err.code);
 }

--- a/src/main/webapp/main.js
+++ b/src/main/webapp/main.js
@@ -150,21 +150,51 @@ function initChat() {
 function getCoords(){
   var latitude;
   var longitude;
+// use watch  positioon, try too break   out of the function
 
+const watchID = navigator.geolocation.watchPosition((position) => {
+    console.log("this is position" + position);
+    console.log(position.coords.latitude + " sdf " + position.coords.longitude);
+    if(position.coords.latitude !== undefined){
+      console.log("changing coordinnates");
+      latitude = -34.397;
+      longitude = 150.644;
+    } else {
+      latitude = position.coords.latitude;
+      longitude = position.coords.longitude;
+    }
+    navigator.geolocation.clearWatch(watchID);
+    console.log([latitude, longitude]);
+    return [latitude, longitude];
+  }, handle_error);
+
+
+/*
   if(navigator.geolocation){
-    navigator.geolocation.getCurrentPosition((position) => {
+    navigator.geolocation.watchPosition(function(position){
+      console.log(JSON.stringify(position));
       latitude = position.coords.latitude,
       longitude = position.coords.longitude;
+      if(latitude === undefined){
+        latitude = -34.397;
+    longitude = 150.644;
+      }
     }, handle_error);
   } else {
     latitude = -34.397;
     longitude = 150.644;
   }
+  console.log("this is lat and lng: " + latitude + " " + longitude);
 
-  return [latitude, longitude];
+
+    navigator.geolocation.clearWatch(id);
+    return [latitude, longitude];
+  */
 
 }
 
 function handle_error(err) {
+  latitude = -34.397;
+  longitude = 150.644;
   console.log(err.code);
 }

--- a/src/main/webapp/main.js
+++ b/src/main/webapp/main.js
@@ -79,7 +79,8 @@ Promise.all([mapPromise, domPromise, firebasePromise]).then(() => {
 
 /**
  * Returns the user's coordinates, if possible
- * @returns{!Object} Tuple representing the user's latitude and longitude
+ * @returns{!Promise<Array<Number>>} Promise for a tuple representing
+ * the user's latitude and longitude.
  */
 function getCoords(){
 

--- a/src/main/webapp/main.js
+++ b/src/main/webapp/main.js
@@ -87,7 +87,7 @@ function getCoords(){
     
     if(navigator.geolocation){
       navigator.geolocation.getCurrentPosition(function(position){
-        if(position.coords.latitude !== undefined){
+        if(position.coords.latitude && position.coords.longitude){
           resolve([position.coords.latitude, position.coords.longitude]);
         } else {
           reject();


### PR DESCRIPTION
Add functionality to center map at the user's location if possible, and default coordinates if not possible.

When the user enters a map, they will be prompted to share their location. In the case that the user allows, the map centers around the user's current GPS coordinates. In all other cases (including navigator.geolocation not being available on the user's device), the map will center around a pair of default coordinates.

Also, move instantiation of user id to a more global context to avoid re-creating it with every invocation of the function.